### PR TITLE
Support more bundle operations in WP-CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .svn/
+.DS_Store

--- a/includes/class-ajax.php
+++ b/includes/class-ajax.php
@@ -53,7 +53,15 @@ class WPCFM_Ajax
     function load_diff() {
         if ( current_user_can( 'manage_options' ) ) {
             $bundle_name = stripslashes( $_POST['data']['bundle_name'] );
-            echo json_encode( WPCFM()->readwrite->compare_bundle( $bundle_name ) );
+            $comparison = WPCFM()->readwrite->compare_bundle( $bundle_name );
+            // The pretty-text-diff.js will do its best on these print_r()s.
+            if ( isset( $comparison['file'] ) ) {
+                $comparison['file'] = print_r( $comparison['file'], true );
+            }
+            if ( isset( $comparison['db'] ) ) {
+                $comparison['db'] = print_r( $comparison['db'], true );
+            }
+            echo json_encode( $comparison );
         }
         exit;
     }

--- a/includes/class-readwrite.php
+++ b/includes/class-readwrite.php
@@ -130,8 +130,8 @@ class WPCFM_Readwrite
         }
         else {
             $return['error'] = '';
-            $return['file'] = print_r( $file_bundle, true );
-            $return['db'] = print_r( $db_bundle, true );
+            $return['file'] = $file_bundle;
+            $return['db'] = $db_bundle;
         }
 
         return $return;

--- a/includes/class-wp-cli.php
+++ b/includes/class-wp-cli.php
@@ -8,18 +8,18 @@ class WPCFM_CLI_Command extends WP_CLI_Command
 
     /**
      * Push a bundle to the filesystem
-     * 
+     *
      * ## OPTIONS
-     * 
+     *
      * <bundle_name>
      * : The bundle name to export (or use "all")
-     * 
+     *
      * ## EXAMPLES
-     * 
+     *
      * wp config push bundle_name
-     * 
+     *
      * @synopsis <bundle_name> [--network]
-     * 
+     *
      */
     function push( $args, $assoc_args ) {
         if ( isset( $assoc_args['network'] ) ) {
@@ -33,18 +33,18 @@ class WPCFM_CLI_Command extends WP_CLI_Command
 
     /**
      * Pull a bundle into the database
-     * 
+     *
      * ## OPTIONS
-     * 
+     *
      * <bundle_name>
      * : The bundle name to import (or use "all")
-     * 
+     *
      * ## EXAMPLES
-     * 
+     *
      * wp config pull bundle_name
-     * 
+     *
      * @synopsis <bundle_name> [--network]
-     * 
+     *
      */
     function pull( $args, $assoc_args ) {
         if ( isset( $assoc_args['network'] ) ) {
@@ -58,21 +58,124 @@ class WPCFM_CLI_Command extends WP_CLI_Command
 
     /**
      * Compare bundle differences
-     * 
+     *
      * ## OPTIONS
-     * 
+     *
      * <bundle_name>
      * : The bundle name to compare (or use "all")
-     * 
+     *
      * ## EXAMPLES
-     * 
+     *
      * wp config diff bundle_name
-     * 
+     *
      * @synopsis <bundle_name>
-     * 
+     *
      */
     function diff( $args, $assoc_args ) {
+        $compare = WPCFM()->readwrite->compare_bundle( $args[0] );
+        if ($compare['error'] !== '') {
+            WP_CLI::warning( $compare['error'] );
+        }
+        else {
+            # Sort these things into stuff that's only in one place,
+            # or where there's actually a diff.
+            $only_db_rows = array();
+            $only_file_rows = array();
+            $diff_rows = array();
+            foreach( $compare['db'] as $key => $value ) {
+                if ( !isset( $compare['file'][$key] ) ) {
+                    $only_db_rows[] = array($key, $value);
+                }
+                elseif ( $value !== $compare['file'][$key] ) {
+                    $diff_rows[$key] = array( $key, $compare['file'][$key], $value );
+                }
+            }
+            foreach( $compare['file'] as $key => $value ) {
+                if ( !isset( $compare['db'][$key] ) ) {
+                    $only_file_rows[] = array( $key, $value );
+                }
+                elseif ( $value !== $compare['db'][$key] ) {
+                    $diff_rows[$key] = array( $key, $compare['file'][$key], $value );
+                }
+            }
+            if ( count( $only_file_rows) > 0 ) {
+                $file = new \cli\Table( array( 'Option', 'Value' ), $only_file_rows);
+                WP_CLI::line( 'Options that are only in files (pull to load)' );
+                $file->display();
+            }
+            if ( count( $only_db_rows) > 0 ) {
+                $db = new \cli\Table( array( 'Option', 'Value' ), $only_db_rows);
+                WP_CLI::line( 'Options that are only in DB (push to write to file)' );
+                $db->display();
+            }
+            if ( count( $diff_rows ) > 0 ) {
+                $diff = new \cli\Table( array( 'Option', 'File value', 'DB value' ), $diff_rows);
+                WP_CLI::line( 'Options in both the database and in files.' );
+                $diff->display();
+            }
+        }
+    }
 
+    /**
+     * Get bundle names
+     *
+     * ## OPTIONS
+     *
+     * ## Examples
+     *
+     * wp config bundles
+     *
+     */
+    function bundles() {
+        $bundles = WPCFM()->helper->get_bundles();
+        $header = array( 'Bundle', 'Label', 'In File', 'In DB', 'Configs' );
+        $table = new \cli\Table( $header, array() );
+        foreach( $bundles as $bundle ) {
+            $row = array( $bundle['name'], $bundle['label'], $bundle['is_file'], $bundle['is_db'] );
+            $row[] = implode( ', ', $bundle['config'] );
+            $table->addrow( $row );
+        }
+        $table->display();
+    }
+
+    /**
+     * Get bundle details
+     *
+     * ## OPTIONS
+     *
+     * <bundle_name>
+     * : The bundle name to inspect.
+     *
+     * ## EXAMPLES
+     *
+     * wp config show_bundle <bundle_name>
+     *
+     * @synopsis <bundle_name>
+     *
+     */
+    function show_bundle( $args, $assoc_args ) {
+        $file_bundle = WPCFM()->readwrite->read_file( $args[0] );
+        $db_bundle = WPCFM()->readwrite->read_db( $args[0] );
+        $header = array( 'Config', 'File value', 'DB value' );
+        $rows = array();
+        foreach( $file_bundle as $key => $value ) {
+            $rows[$key] = array( $key, $value );
+            if ( isset( $db_bundle[$key] ) ) {
+                $rows[$key][] = $db_bundle[$key];
+            }
+            else {
+                $rows[$key][] = 'n/a';
+            }
+        }
+        foreach( $file_bundle as $key => $value ) {
+            if ( !isset( $db_bundle[$key] ) ) {
+                $rows[$key] = array( $key, 'n/a', $db_bundle[$key] );
+            }
+        }
+        unset( $rows['.label'] );
+        ksort($rows);
+        $table = new \cli\Table( $header, $rows );
+        $table->display();
     }
 }
 


### PR DESCRIPTION
Adding some more cli love: `diff`, `bundles', and `show_bundle` commands.

This also required changing some code in how the diffs were generated. Seemed more right for the core function to stick to structured data though, and do the conversion to a string via `print_r()` as part of the AJAX response path, since that's specifically for the JS differ to consume.

![selfie-0](http://i.imgur.com/6wZRfWP.png)
