### PR TITLE
fix error notice on PHP7

### DIFF
--- a/includes/class-readwrite.php
+++ b/includes/class-readwrite.php
@@ -334,7 +334,8 @@ class WPCFM_Readwrite
 
             if ( is_callable( $callback ) ) {
                 if ( is_array( $callback ) ) {
-                    $success = $callback[0]->$callback[1]( $callback_params );
+                    $function = $callback[1];
+                    $success = $callback[0]->$function( $callback_params );
                 }
                 else {
                     $success = $callback( $callback_params );


### PR DESCRIPTION
On PHP7 the plugin threw the following errors

`Notice: Array to string conversion`
`Notice: Undefined property: WPCFM_Readwrite::$Array`
`Fatal error: Uncaught Error: Function name must be a string `

wrapping the callback function into a plain variable resolves this error.