### PR TITLE
Early exit of configuration_items() in taxonomy.php

### DIFF
--- a/includes/integrations/taxonomy.php
+++ b/includes/integrations/taxonomy.php
@@ -35,8 +35,8 @@ class WPCFM_Taxonomy
                 'group' => 'Taxonomy Terms',
             );
 
-            return $items;
         }
+        return $items;
     }
 
 


### PR DESCRIPTION
Moved "return $items" out of the foreach loop in configuration_items(). This was causing only the first taxonomy to be returned to the bundle admin GUI. 