### PR TITLE
Make sure opts is populated before indexing into it.

### DIFF
--- a/includes/class-helper.php
+++ b/includes/class-helper.php
@@ -12,10 +12,13 @@ class WPCFM_Helper
         // Get DB bundles first
         $opts = WPCFM()->options->get( 'wpcfm_settings' );
         $opts = json_decode( $opts, true );
-        foreach ( $opts['bundles'] as $bundle ) {
-            $bundle['is_db'] = true;
-            $bundle['is_file'] = false;
-            $output[ $bundle['name'] ] = $bundle;
+
+        if ( isset( $opts['bundles'] ) ) {
+            foreach ( $opts['bundles'] as $bundle ) {
+                $bundle['is_db'] = true;
+                $bundle['is_file'] = false;
+                $output[ $bundle['name'] ] = $bundle;
+            }
         }
 
         // Then merge file bundles


### PR DESCRIPTION
 Fixes #62

Looks like this warning happens when you push and there's no config yet. I copied this `isset()` check from a similar one made in `WPCFM_Readwrite::pull_bundle`, so - seemed legit.