### PR TITLE
[FEATURE] Recreate missing serialized options on import

### DIFF
--- a/includes/class-readwrite.php
+++ b/includes/class-readwrite.php
@@ -330,6 +330,16 @@ class WPCFM_Readwrite
     function callback_wp_options( $params ) {
         $option_name = $params['name'];
         $option_value = maybe_unserialize( $params['new_value'] );
+        $option_db_value = maybe_unserialize( $params['old_value'] );
+
+        // Ensure that all serialized options will still exist
+        if (defined('WPCFM_CONFIG_KEEP_MISSING_OPTIONS_ON_IMPORT') && WPCFM_CONFIG_KEEP_MISSING_OPTIONS_ON_IMPORT) {
+            foreach ( $option_db_value as $key => $value ) {
+                if ( ! array_key_exists( $key, $option_value ) ) {
+                    $option_value[ $key ] = $value;
+                }
+            }
+        }
         WPCFM()->options->update( $option_name, $option_value );
     }
 }

--- a/includes/class-readwrite.php
+++ b/includes/class-readwrite.php
@@ -333,7 +333,7 @@ class WPCFM_Readwrite
         $option_db_value = maybe_unserialize( $params['old_value'] );
 
         // Ensure that all serialized options will still exist
-        if (defined('WPCFM_CONFIG_KEEP_MISSING_OPTIONS_ON_IMPORT') && WPCFM_CONFIG_KEEP_MISSING_OPTIONS_ON_IMPORT) {
+        if (defined('WPCFM_CONFIG_KEEP_MISSING_OPTIONS_ON_IMPORT') && WPCFM_CONFIG_KEEP_MISSING_OPTIONS_ON_IMPORT && is_array($option_db_value) && is_array($option_value)) {
             foreach ( $option_db_value as $key => $value ) {
                 if ( ! array_key_exists( $key, $option_value ) ) {
                     $option_value[ $key ] = $value;

--- a/wp-cfm.php
+++ b/wp-cfm.php
@@ -53,6 +53,8 @@ class WPCFM_Core
         } else {
           define( 'WPCFM_CONFIG_FORMAT',  apply_filters( 'wpcfm_config_format', 'json'));
         }
+
+        define( 'WPCFM_CONFIG_KEEP_MISSING_OPTIONS_ON_IMPORT', apply_filters( 'wpcfm_config_keep_missing_options_on_import', false));
         define( 'WPCFM_URL', plugins_url( '', __FILE__ ) );
 
         // WP is loaded


### PR DESCRIPTION
Some plugins save options as serialized data. This feature allow to save only a part of these serialized data in the config files and still ensure that missing serialized option won't be deleted on import.