### PR TITLE
Fix CFS plugin detection

### DIFF
--- a/includes/integrations/custom-field-suite.php
+++ b/includes/integrations/custom-field-suite.php
@@ -162,6 +162,6 @@ class WPCFM_Custom_Field_Suite
 }
 
 // Requires CFS
-if ( is_plugin_active( 'custom-field-suite/cfs.php' ) ) {
+if ( class_exists( 'Custom_Field_Suite' ) ) {
     new WPCFM_Custom_Field_Suite();
 }


### PR DESCRIPTION
If Custom Field Suite is installed as an mu-plugin, wp-cfm does not detect that it's active.

Before the change, `is_plugin_active( 'custom-field-suite/cfs.php' )` returned false if Custom Field Suite was installed as an mu-plugin. Now, `class_exists( 'Custom_Field_Suite' )`, detects Custom Field Suite whether it's a normal plugin or an mu-plugin. This fixes the CFS integration in wp-cfm.