### PR TITLE
Cache results of WPCFM_Registry::get_configuration_items

### DIFF
--- a/includes/class-readwrite.php
+++ b/includes/class-readwrite.php
@@ -6,6 +6,7 @@ class WPCFM_Readwrite
 
     public $folder;
     public $error;
+    static $db_data;
 
 
     function __construct() {
@@ -284,7 +285,10 @@ return array();
     function write_db( $bundle_name, $file_data ) {
 
         $success = false;
-        $db_data = WPCFM()->registry->get_configuration_items();
+        if ( empty( static::$db_data ) ) {
+            static::$db_data = WPCFM()->registry->get_configuration_items();
+        }
+        $db_data = static::$db_data;
 
         foreach ( $file_data as $key => $val ) {
 

--- a/includes/class-readwrite.php
+++ b/includes/class-readwrite.php
@@ -6,7 +6,7 @@ class WPCFM_Readwrite
 
     public $folder;
     public $error;
-    static $db_data;
+    public $db_data;
 
 
     function __construct() {
@@ -285,10 +285,10 @@ return array();
     function write_db( $bundle_name, $file_data ) {
 
         $success = false;
-        if ( empty( static::$db_data ) ) {
-            static::$db_data = WPCFM()->registry->get_configuration_items();
+        if ( empty( $this->db_data ) ) {
+            $this->db_data = WPCFM()->registry->get_configuration_items();
         }
-        $db_data = static::$db_data;
+        $db_data = $this->db_data;
 
         foreach ( $file_data as $key => $val ) {
 


### PR DESCRIPTION
See https://github.com/forumone/wp-cfm/issues/116.

WPCFM_Readwrite::write_db is called from inside a foreach loop,
once per bundle.
This function calls WPCFM_Registry::get_configuration_items
which loads all rows from wp_options into an array.

Loading the data only once (the first time it is needed)
and keeping it cached improves performance on sites with
a big number of options and bundles.