### PR TITLE
Replace WP_HOME with home_url()

### DIFF
--- a/wp-cfm.php
+++ b/wp-cfm.php
@@ -62,7 +62,7 @@ class WPCFM_Core
 
             // Change the config directory to private/config on Pantheon
             $config_dir = $_SERVER['DOCUMENT_ROOT'] . '/private/config';
-            $config_url = WP_HOME . '/private/config';
+            $config_url = home_url() . '/private/config';
         }
 
         // Register multiple environments.


### PR DESCRIPTION
WP_HOME isn't always guaranteed to be set, so replace with WordPress core function, home_url().

https://developer.wordpress.org/reference/functions/home_url/

fixes #113