### PR TITLE
Fix Warning: Invalid argument supplied for foreach() on CLI

### DIFF
--- a/includes/class-readwrite.php
+++ b/includes/class-readwrite.php
@@ -145,7 +145,7 @@ class WPCFM_Readwrite
         unset( $file_bundle['.label'] );
 
         // Convert to YAML for better readability if PHP version is compatible
-        if (PHP_VERSION_ID >= 50604 && WPCFM_CONFIG_USE_YAML_DIFF) {
+        if (PHP_VERSION_ID >= 50604 && WPCFM_CONFIG_USE_YAML_DIFF && !defined( 'WP_CLI' )) {
             $file_bundle = WPCFM_Helper::convert_to_yaml($file_bundle, false);
             $db_bundle   = WPCFM_Helper::convert_to_yaml($db_bundle, false);
         }


### PR DESCRIPTION
Fix Warning: Invalid argument supplied for foreach() in /wordpress/wp-content/plugins/wp-cfm/includes/class-wp-cli.php when using WP CLI (wp config diff all)