### PR TITLE
[IMPROVEMENT] Add support for PHP object dumping and parsing when using the YAML format

### DIFF
--- a/includes/class-helper.php
+++ b/includes/class-helper.php
@@ -166,7 +166,7 @@ class WPCFM_Helper
                 }
             }
         }
-        return Yaml::dump($data, 10);
+        return Yaml::dump($data, 10, 4, Yaml::DUMP_OBJECT);
     }
 
 }

--- a/includes/class-readwrite.php
+++ b/includes/class-readwrite.php
@@ -196,7 +196,7 @@ class WPCFM_Readwrite
                 return json_decode( $contents, true );
             }
             elseif (in_array(WPCFM_CONFIG_FORMAT, array('yaml', 'yml'))) {
-              $array = Yaml::parse($contents);
+              $array = Yaml::parse($contents, Yaml::PARSE_OBJECT);
               foreach ($array as $key => $value) {
                 $format = array();
                 if (preg_match('/\.(.*)_format/i', $key, $format)) {


### PR DESCRIPTION
For a greater support of WordPress plugins configuration stored in the `wp_options` table, the [YAML format](https://github.com/forumone/wp-cfm/wiki/Filters-Reference#wpcfm_config_format) for file bundles should also use the `Yaml::DUMP_OBJECT` and `Yaml::PARSE_OBJECT` flags when called the `Yaml::dump()` and `Yaml::parse()` methods. 

Here the documentation for them: https://symfony.com/doc/current/components/yaml.html#object-parsing-and-dumping

**The case how I found this:**
While using the [WPML](https://wpml.org) plugin and YAML format enabled for WP-CFM, I noted that some configuration keys saved in `wp_options` included serialized arrays with PHP class objects within them. These ones were not getting exported completely as needed to the YAML file bundle.

Example:
The `wpml_language_switcher` option key stores in `wp_options` a serialized array like this:
```
a:6:{s:8:"migrated";i:0;s:18:"converted_menu_ids";i:0;s:14:"additional_css";s:0:"";s:5:"menus";a:0:{}s:8:"sidebars";a:0:{}s:7:"statics";a:3:{s:6:"footer";O:19:"WPML_LS_Footer_Slot":2:{s:24:"WPML_LS_Slotproperties";a:21:{s:10:"slot_group";s:7:"statics";s:9:"slot_slug";s:6:"footer";s:4:"show";i:0;s:8:"template";s:27:"wpml-legacy-horizontal-list";s:13:"display_flags";i:0;s:29:"display_link_for_current_lang";i:0;s:28:"display_names_in_native_lang";i:0;s:29:"display_names_in_current_lang";i:1;s:18:"include_flag_width";i:18;s:19:"include_flag_height";i:12;s:17:"background_normal";N;s:13:"border_normal";N;s:19:"font_current_normal";N;s:18:"font_current_hover";N;s:25:"background_current_normal";N;s:24:"background_current_hover";N;s:17:"font_other_normal";N;s:16:"font_other_hover";N;s:23:"background_other_normal";N;s:22:"background_other_hover";N;s:15:"template_string";N;}s:34:"WPML_LS_Slotprotected_properties";a:2:{i:0;s:10:"slot_group";i:1;s:9:"slot_slug";}}s:17:"post_translations";O:30:"WPML_LS_Post_Translations_Slot":2:{s:24:"WPML_LS_Slotproperties";a:24:{s:10:"slot_group";s:7:"statics";s:9:"slot_slug";s:17:"post_translations";s:4:"show";i:0;s:8:"template";s:29:"wpml-legacy-post-translations";s:13:"display_flags";i:0;s:29:"display_link_for_current_lang";i:0;s:28:"display_names_in_native_lang";i:0;s:29:"display_names_in_current_lang";i:1;s:18:"include_flag_width";i:18;s:19:"include_flag_height";i:12;s:17:"background_normal";N;s:13:"border_normal";N;s:19:"font_current_normal";N;s:18:"font_current_hover";N;s:25:"background_current_normal";N;s:24:"background_current_hover";N;s:17:"font_other_normal";N;s:16:"font_other_hover";N;s:23:"background_other_normal";N;s:22:"background_other_hover";N;s:15:"template_string";N;s:22:"display_before_content";i:1;s:21:"display_after_content";i:0;s:17:"availability_text";s:34:"This post is also available in: %s";}s:34:"WPML_LS_Slotprotected_properties";a:2:{i:0;s:10:"slot_group";i:1;s:9:"slot_slug";}}s:17:"shortcode_actions";O:30:"WPML_LS_Shortcode_Actions_Slot":2:{s:24:"WPML_LS_Slotproperties";a:21:{s:10:"slot_group";s:7:"statics";s:9:"slot_slug";s:17:"shortcode_actions";s:4:"show";i:0;s:8:"template";s:27:"wpml-legacy-horizontal-list";s:13:"display_flags";i:0;s:29:"display_link_for_current_lang";i:0;s:28:"display_names_in_native_lang";i:0;s:29:"display_names_in_current_lang";i:1;s:18:"include_flag_width";i:18;s:19:"include_flag_height";i:12;s:17:"background_normal";N;s:13:"border_normal";N;s:19:"font_current_normal";N;s:18:"font_current_hover";N;s:25:"background_current_normal";N;s:24:"background_current_hover";N;s:17:"font_other_normal";N;s:16:"font_other_hover";N;s:23:"background_other_normal";N;s:22:"background_other_hover";N;s:15:"template_string";N;}s:34:"WPML_LS_Slotprotected_properties";a:2:{i:0;s:10:"slot_group";i:1;s:9:"slot_slug";}}}}
```
Within this serialized array string value, there are PHP class objects, also string serialized, like these ones:

- `WPML_LS_Footer_Slot`
- `WPML_LS_Post_Translations_Slot`
- `WPML_LS_Shortcode_Actions_Slot`
- `...`

After selecting the `wpml_language_switcher` option key to be tracked with the bundle and pushing to create the YAML file (`wp config push wpml`) it dumped into the bundle file a YAML structure with `null` values under the sub keys that holds these serialized PHP class objects:
```yaml
wpml_language_switcher:
    migrated: 0
    converted_menu_ids: 0
    additional_css: ''
    menus: {  }
    sidebars: {  }
    statics:
        footer: null
        post_translations: null
        shortcode_actions: null
```
In result, this produced an incomplete configuration import for the `wpml_language_switcher` key (when running `wp config pull wpml`) and therefore a fatal error as soon it's refreshed the WordPress backend.

**The solution:**
After updating the plugin methods `convert_to_yaml()` and `read_file()` to use the flags `Yaml::DUMP_OBJECT` and `Yaml::PARSE_OBJECT` on `Yaml::dump()` and `Yaml::parse()` calls respectively, the YAML structure dumped into the bundle file now includes these serialized PHP class objects (example below) and this config export / import now is fully complete without missing parts.

```yaml
wpml_language_switcher:
    migrated: 0
    converted_menu_ids: 0
    additional_css: ''
    menus: {  }
    sidebars: {  }
    statics:
        footer: !php/object:O:19:"WPML_LS_Footer_Slot":2:{s:24:" WPML_LS_Slot properties";a:21:{s:10:"slot_group";s:7:"statics";s:9:"slot_slug";s:6:"footer";s:4:"show";i:0;s:8:"template";s:27:"wpml-legacy-horizontal-list";s:13:"display_flags";i:0;s:29:"display_link_for_current_lang";i:0;s:28:"display_names_in_native_lang";i:0;s:29:"display_names_in_current_lang";i:1;s:18:"include_flag_width";i:18;s:19:"include_flag_height";i:12;s:17:"background_normal";N;s:13:"border_normal";N;s:19:"font_current_normal";N;s:18:"font_current_hover";N;s:25:"background_current_normal";N;s:24:"background_current_hover";N;s:17:"font_other_normal";N;s:16:"font_other_hover";N;s:23:"background_other_normal";N;s:22:"background_other_hover";N;s:15:"template_string";N;}s:34:" WPML_LS_Slot protected_properties";a:2:{i:0;s:10:"slot_group";i:1;s:9:"slot_slug";}}
        post_translations: !php/object:O:30:"WPML_LS_Post_Translations_Slot":2:{s:24:" WPML_LS_Slot properties";a:24:{s:10:"slot_group";s:7:"statics";s:9:"slot_slug";s:17:"post_translations";s:4:"show";i:0;s:8:"template";s:29:"wpml-legacy-post-translations";s:13:"display_flags";i:0;s:29:"display_link_for_current_lang";i:0;s:28:"display_names_in_native_lang";i:0;s:29:"display_names_in_current_lang";i:1;s:18:"include_flag_width";i:18;s:19:"include_flag_height";i:12;s:17:"background_normal";N;s:13:"border_normal";N;s:19:"font_current_normal";N;s:18:"font_current_hover";N;s:25:"background_current_normal";N;s:24:"background_current_hover";N;s:17:"font_other_normal";N;s:16:"font_other_hover";N;s:23:"background_other_normal";N;s:22:"background_other_hover";N;s:15:"template_string";N;s:22:"display_before_content";i:1;s:21:"display_after_content";i:0;s:17:"availability_text";s:34:"This post is also available in: %s";}s:34:" WPML_LS_Slot protected_properties";a:2:{i:0;s:10:"slot_group";i:1;s:9:"slot_slug";}}
        shortcode_actions: !php/object:O:30:"WPML_LS_Shortcode_Actions_Slot":2:{s:24:" WPML_LS_Slot properties";a:21:{s:10:"slot_group";s:7:"statics";s:9:"slot_slug";s:17:"shortcode_actions";s:4:"show";i:0;s:8:"template";s:27:"wpml-legacy-horizontal-list";s:13:"display_flags";i:0;s:29:"display_link_for_current_lang";i:0;s:28:"display_names_in_native_lang";i:0;s:29:"display_names_in_current_lang";i:1;s:18:"include_flag_width";i:18;s:19:"include_flag_height";i:12;s:17:"background_normal";N;s:13:"border_normal";N;s:19:"font_current_normal";N;s:18:"font_current_hover";N;s:25:"background_current_normal";N;s:24:"background_current_hover";N;s:17:"font_other_normal";N;s:16:"font_other_hover";N;s:23:"background_other_normal";N;s:22:"background_other_hover";N;s:15:"template_string";N;}s:34:" WPML_LS_Slot protected_properties";a:2:{i:0;s:10:"slot_group";i:1;s:9:"slot_slug";}}
```

In short, we need to tell the `symfony/yaml` package responsible of pushing and reading YAML file bundles how to handle these cases where serialized PHP class objects might exists on certain plugins configurations, specially quite advanced ones like WPML.