### PR TITLE
fix(readwrite): Add check to skip pulling a bundle if there was no matching bundle file

### DIFF
--- a/includes/class-readwrite.php
+++ b/includes/class-readwrite.php
@@ -52,37 +52,37 @@ class WPCFM_Readwrite
 
             // If we import wpcfm settings don't update it
             if (!$dontUpdateSettings) {
-              $dontUpdateSettings = $bundle_name == 'wpcfm';
-          }
-          if ($dontUpdateSettings) {
-              continue;
-          }
+                $dontUpdateSettings = $bundle_name == 'wpcfm';
+            }
+            if ($dontUpdateSettings) {
+                continue;
+            }
 
             // Update the bundle's config options (using the pull file)
-          $exists = false;
-          foreach ( $settings['bundles'] as $key => $bundle_settings ) {
-            if ( $bundle_name == $bundle_settings['name'] ) {
-                $settings['bundles'][ $key ]['label'] = $bundle_label;
-                $settings['bundles'][ $key ]['config'] = array_keys( $data );
-                $exists = true;
-                break;
+            $exists = false;
+            foreach ( $settings['bundles'] as $key => $bundle_settings ) {
+                if ( $bundle_name == $bundle_settings['name'] ) {
+                    $settings['bundles'][ $key ]['label'] = $bundle_label;
+                    $settings['bundles'][ $key ]['config'] = array_keys( $data );
+                    $exists = true;
+                    break;
+                }
+            }
+
+            if ( ! $exists ) {
+                $settings['bundles'][] = array(
+                    'label'     => $bundle_label,
+                    'name'      => $bundle_name,
+                    'config'    => array_keys( $data ),
+                );
             }
         }
 
-        if ( ! $exists ) {
-            $settings['bundles'][] = array(
-                'label'     => $bundle_label,
-                'name'      => $bundle_name,
-                'config'    => array_keys( $data ),
-            );
+        // Write the settings
+        if (!$dontUpdateSettings) {
+            WPCFM()->options->update( 'wpcfm_settings', json_encode( $settings ) );
         }
     }
-
-        // Write the settings
-    if (!$dontUpdateSettings) {
-      WPCFM()->options->update( 'wpcfm_settings', json_encode( $settings ) );
-  }
-}
 
 
     /**
@@ -100,7 +100,7 @@ class WPCFM_Readwrite
             $data['.label'] = $bundle_meta['label'];
 
             if (WPCFM_CONFIG_FORMAT == 'json') {
-            // JSON_PRETTY_PRINT for PHP 5.4+
+                // JSON_PRETTY_PRINT for PHP 5.4+
                 $data = version_compare( PHP_VERSION, '5.4.0', '>=' ) ?
                 json_encode( $data, JSON_PRETTY_PRINT ) :
                 json_encode( $data );
@@ -196,26 +196,26 @@ class WPCFM_Readwrite
                 return json_decode( $contents, true );
             }
             elseif (in_array(WPCFM_CONFIG_FORMAT, array('yaml', 'yml'))) {
-              $array = Yaml::parse($contents);
-              foreach ($array as $key => $value) {
-                $format = array();
-                if (preg_match('/\.(.*)_format/i', $key, $format)) {
-                  switch ($array[$format[0]]) {
-                    case 'serialized':
-                    $array[$format[1]] = serialize($array[$format[1]]);
-                    break;
-                    case 'json':
-                    $array[$format[1]] = json_encode($array[$format[1]]);
-                    break;
+                $array = Yaml::parse($contents);
+                foreach ($array as $key => $value) {
+                    $format = array();
+                    if (preg_match('/\.(.*)_format/i', $key, $format)) {
+                        switch ($array[$format[0]]) {
+                            case 'serialized':
+                                $array[$format[1]] = serialize($array[$format[1]]);
+                                break;
+                            case 'json':
+                                $array[$format[1]] = json_encode($array[$format[1]]);
+                                break;
+                        }
+                        unset($array[$format[0]]);
+                    }
                 }
-                unset($array[$format[0]]);
+                return $array;
             }
         }
-        return $array;
+        return array();
     }
-}
-return array();
-}
 
 
     /**

--- a/includes/class-readwrite.php
+++ b/includes/class-readwrite.php
@@ -45,6 +45,12 @@ class WPCFM_Readwrite
         // Import each bundle into DB
         foreach ( $bundles as $bundle_name ) {
             $data = $this->read_file( $bundle_name );
+
+            // Skip bundle if no file matching the bundle name was found
+            if (empty($data)) {
+                continue;
+            }
+
             $bundle_label = $data['.label'];
             unset( $data['.label'] );
 

--- a/includes/class-readwrite.php
+++ b/includes/class-readwrite.php
@@ -46,8 +46,8 @@ class WPCFM_Readwrite
         foreach ( $bundles as $bundle_name ) {
             $data = $this->read_file( $bundle_name );
 
-            // Skip bundle if no file matching the bundle name was found
-            if (empty($data)) {
+            // Skip bundle if no file matching the bundle name was found.
+            if ( empty( $data ) ) {
                 continue;
             }
 
@@ -57,10 +57,10 @@ class WPCFM_Readwrite
             $this->write_db( $bundle_name, $data );
 
             // If we import wpcfm settings don't update it
-            if (!$dontUpdateSettings) {
+            if ( ! $dontUpdateSettings ) {
                 $dontUpdateSettings = $bundle_name == 'wpcfm';
             }
-            if ($dontUpdateSettings) {
+            if ( $dontUpdateSettings ) {
                 continue;
             }
 
@@ -85,7 +85,7 @@ class WPCFM_Readwrite
         }
 
         // Write the settings
-        if (!$dontUpdateSettings) {
+        if ( ! $dontUpdateSettings ) {
             WPCFM()->options->update( 'wpcfm_settings', json_encode( $settings ) );
         }
     }
@@ -106,7 +106,7 @@ class WPCFM_Readwrite
             $data['.label'] = $bundle_meta['label'];
 
             if (WPCFM_CONFIG_FORMAT == 'json') {
-                // JSON_PRETTY_PRINT for PHP 5.4+
+                // JSON_PRETTY_PRINT for PHP 5.4+.
                 $data = version_compare( PHP_VERSION, '5.4.0', '>=' ) ?
                 json_encode( $data, JSON_PRETTY_PRINT ) :
                 json_encode( $data );
@@ -202,19 +202,19 @@ class WPCFM_Readwrite
                 return json_decode( $contents, true );
             }
             elseif (in_array(WPCFM_CONFIG_FORMAT, array('yaml', 'yml'))) {
-                $array = Yaml::parse($contents);
-                foreach ($array as $key => $value) {
+                $array = Yaml::parse( $contents );
+                foreach ( $array as $key => $value ) {
                     $format = array();
-                    if (preg_match('/\.(.*)_format/i', $key, $format)) {
-                        switch ($array[$format[0]]) {
+                    if ( preg_match( '/\.(.*)_format/i', $key, $format ) ) {
+                        switch ( $array[ $format[0] ] ) {
                             case 'serialized':
-                                $array[$format[1]] = serialize($array[$format[1]]);
+                                $array[ $format[1] ] = serialize( $array[ $format[1] ] );
                                 break;
                             case 'json':
-                                $array[$format[1]] = json_encode($array[$format[1]]);
+                                $array[ $format[1] ] = json_encode( $array[ $format[1] ] );
                                 break;
                         }
-                        unset($array[$format[0]]);
+                        unset( $array[ $format[0] ] );
                     }
                 }
                 return $array;


### PR DESCRIPTION
In a situation where a bundle pull fails to find an associated bundle file, an empty bundle is written to the database. This PR adds a check after reading the file, skipping the bundle if no file was found.

I don't see where this might happen through the plugin today (In CLI there is already a check for a valid bundle), but calls to `WPCFM_Readwrite->pull_bundle()` directly can result in this happening. 

There's a separate commit in this PR to clean up the indentation on this file, as well. 