### PR TITLE
Add support for a config-split style functionality

### DIFF
--- a/includes/class-helper.php
+++ b/includes/class-helper.php
@@ -55,16 +55,17 @@ class WPCFM_Helper
      * Get file bundles
      */
     function get_file_bundles() {
+        $config_env_dir = \trailingslashit( WPCFM_CONFIG_DIR . '/' . WPCFM_CURRENT_ENV );
 
         $output = array();
-        $filenames = array_filter( scandir( WPCFM_CONFIG_DIR ), function( $item ) {
-            return !is_dir( WPCFM_CONFIG_DIR . '/' . $item );
+        $filenames = array_filter( scandir( $config_env_dir  ), function( $item ) use( $config_env_dir ) {
+            return !is_dir( $config_env_dir . $item );
         });
 
         foreach ( $filenames as $filename ) {
 
-            // Ignore dot files
-            if ( '.' == substr( $filename, 0, 1 ) ) {
+            // Ignore dot and default files
+            if ( '.' == substr( $filename, 0, 1 ) || 0 === strpos( $filename, 'default' ) ) {
                 continue;
             }
 

--- a/includes/class-readwrite.php
+++ b/includes/class-readwrite.php
@@ -5,6 +5,7 @@ class WPCFM_Readwrite
 {
 
     public $folder;
+    public $env;
     public $error;
     public $db_data;
 
@@ -13,6 +14,7 @@ class WPCFM_Readwrite
 
         // Create the "config" folder
         $this->folder = WPCFM_CONFIG_DIR;
+        $this->env = WPCFM_CURRENT_ENV;
 
         if ( ! is_dir( $this->folder ) ) {
             if ( ! wp_mkdir_p( $this->folder ) ) {
@@ -174,28 +176,72 @@ class WPCFM_Readwrite
      * Returns the bundle filename.
      * @return string
      */
-    function bundle_filename( $bundle_name ) {
+    function bundle_filename( $bundle_name, $env = '' ) {
+        $env = trailingslashit( $env ?: $this->env );
         $filename = "$this->folder/$bundle_name." . WPCFM_CONFIG_FORMAT;
+        $filename = "$this->folder/{$env}{$bundle_name}." . WPCFM_CONFIG_FORMAT;
 
         if ( is_multisite() ) {
             if ( WPCFM()->options->is_network ) {
-                $filename = "$this->folder/network-$bundle_name." . WPCFM_CONFIG_FORMAT;
+                $filename = "$this->folder/{$env}network-$bundle_name." . WPCFM_CONFIG_FORMAT;
             }
             else {
-                $filename = "$this->folder/blog" . get_current_blog_id() . "-$bundle_name." . WPCFM_CONFIG_FORMAT;
+                $filename = "$this->folder/{$env}blog" . get_current_blog_id() . "-$bundle_name." . WPCFM_CONFIG_FORMAT;$filename = "$this->folder/blog" . get_current_blog_id() . "-$bundle_name." . WPCFM_CONFIG_FORMAT;
             }
         }
 
         return $filename;
     }
 
-
     /**
-     * Load the file bundle
+     * Load a file bundle's compiled config
+     *
+     * - private/config/
+     *   - dev/
+     *     - default-bundle.json
+     *     - blog1-bundle.json
+     *     - blog2-bundle.json
+     *   - test/
+     *     - default-bundle.json
+     *     - blog1-bundle.json
+     *     - blog2-bundle.json
+     *   - live/
+     *     - default-bundle.json
+     *     - blog1-bundle.json
+     *     - blog2-bundle.json
+     *   - default/
+     *     - bundle.json
+     *
      * @return array
      */
     function read_file( $bundle_name ) {
-        $filename = $this->bundle_filename( $bundle_name );
+        $bundle_name = substr( $bundle_name, -1 * strlen( WPCFM_CONFIG_FORMAT ) ) != WPCFM_CONFIG_FORMAT
+            ? $bundle_name
+            : substr( $bundle_name, 0, strlen( $bundle_name ) - strlen( WPCFM_CONFIG_FORMAT ) - 1 );
+
+        $configs = [];
+
+        // Get config from the default "environment"
+        $default_file = "$this->folder/default/$bundle_name." . WPCFM_CONFIG_FORMAT;
+        $default_config = $this->parse_file( $default_file );
+
+        $env_default_file = "$this->folder/$this->env/default-$bundle_name." . WPCFM_CONFIG_FORMAT;
+        $env_default_config = $this->parse_file( $env_default_file );
+
+        $bundle_file = $this->bundle_filename( $bundle_name );
+        $bundle_config = $this->parse_file( $bundle_file );
+
+        $config = array_merge( $default_config, $env_default_config, $bundle_config );
+
+        return apply_filters( 'wpcfm_bundle_config', $config, $bundle_name, $this->env );
+    }
+
+    /**
+     * Parse the contents of a single file.
+     * @return array
+     */
+    function parse_file( $filename ) {
+        $array = [];
         if ( is_readable( $filename ) ) {
             $contents = file_get_contents( $filename );
             if (WPCFM_CONFIG_FORMAT == 'json') {

--- a/wp-cfm.php
+++ b/wp-cfm.php
@@ -68,16 +68,7 @@ class WPCFM_Core
         // Register multiple environments.
         define( 'WPCFM_REGISTER_MULTI_ENV', $this->set_multi_env() );
 
-        // If multiple environments were defined.
-        if ( !empty( WPCFM_REGISTER_MULTI_ENV ) ) {
-            // Set the current environment where the WordPress site is running.
-            define( 'WPCFM_CURRENT_ENV',  $this->set_current_env() );
-            // If we have an env name, append it to create a subfolder inside wp-content/config/ directory.
-            if ( !empty( WPCFM_CURRENT_ENV ) ) {
-                $config_dir .= '/' . WPCFM_CURRENT_ENV;
-                $config_url .= '/' . WPCFM_CURRENT_ENV;
-            }
-        }
+        define( 'WPCFM_CURRENT_ENV',  $this->set_current_env() );
 
         define( 'WPCFM_CONFIG_DIR', apply_filters( 'wpcfm_config_dir', $config_dir ) );
         define( 'WPCFM_CONFIG_URL', apply_filters( 'wpcfm_config_url', $config_url ) );


### PR DESCRIPTION
Addresses #140 

It supports the ability to define "default" files for bundles. The default gets merged in with the normal bundle files. 

For a multisite, the file structure can look like

```
- private/config/
  - dev/
    - default-bundle.json
    - blog1-bundle.json
    - blog2-bundle.json
  - test/
    - default-bundle.json
    - blog1-bundle.json
    - blog2-bundle.json
  - live/
    - default-bundle.json
    - blog1-bundle.json
    - blog2-bundle.json
  - default/
    - bundle.json
```

It merges in the bundle files in the order `default/bundle.json` → `dev/default-bundle.json` → `dev/blog1-bundle.json` Settings further downstream will overwrite settings from upstream.