### PR TITLE
chore(ci): Fixes New Release Changelog Generation GitHub Actions Step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
       uses: requarks/changelog-action@v1
       with:
         token: ${{ github.token }}
-        fromTag: ${{ github.ref_name }}
+        fromTag: release
         toTag: ${{ steps.semver.outputs.current }}
 
     - name: Install Composer Dependencies


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/forumone/wp-cfm/blob/develop/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

* Changes the `fromTag` to point specifically to the `release` branch when generating a new changelog during new release builds.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
* Changes the `fromTag` to point specifically to the `release` branch when generating a new changelog during new release builds.

