### PR TITLE
chore(ci): Fixes Missing Quotes During Temp Changelog Output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
         toTag: ${{ steps.semver.outputs.current }}
 
     - name: Generate Changelog Temp File
-      run: printf ${{ steps.release-name.outputs.RELEASE_NAME }}\n${{ steps.changelog.outputs.changes }} > changelog.txt
+      run: printf "${{ steps.release-name.outputs.RELEASE_NAME }}\n${{ steps.changelog.outputs.changes }}" > changelog.txt
 
     - name: Install Composer Dependencies
       run: composer install --no-dev --prefer-dist


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/forumone/wp-cfm/blob/develop/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

* Adds missing double quote around the `printf` call when generating the temporary changelog file.

