### PR TITLE
chore(ci): Forces Use of Release Branch for New Release Commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,4 +126,5 @@ jobs:
       with:
         email: support+f1builder@forumone.com
         name: F1 Builder
+        branch: release
         message: ${{ steps.commit-msg.outputs.COMMIT_MSG }}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/forumone/wp-cfm/blob/develop/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

* Fixes the new release build commit GHA step to force the use of the `release` branch.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->

