### PR TITLE
chore(ci): Fixes Release Tag Format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  ACTION_VERSION: 1
+  ACTION_VERSION: 2
 
 jobs:
   release:
@@ -50,7 +50,7 @@ jobs:
       uses: ncipollo/release-action@v1.12.0
       with:
         name: ${{ steps.release-name.outputs.RELEASE_NAME }}
-        tag: ${{ steps.semver.outputs.next }}
+        tag: ${{ steps.semver.outputs.nextStrict }}
         commit: ${{ github.sha }}
         body: ${{ steps.changelog.outputs.changes }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Change Log
 
-## [release] - 2023-10-31
+## 1.7.8 - 20230-10-31
+### :bug: Bug Fixes
+- [`4e13f08`](https://github.com/forumone/wp-cfm/commit/4e13f08df6419656742e25f89f73dc9af826aeb5) - **deploy**: Fixes GHA for WP.org Deployments *(PR #167 by @timnolte)*
+
+### :wrench: Chores
+- [`9ae1ae3`](https://github.com/forumone/wp-cfm/commit/9ae1ae31872e748d6aefd2c9489ca0a2ddf67cbc) - **release**: Updates and builds for release 1.7.8 *(commit by @f1builder)*
+
+## 1.7.7 - 2023-10-31
+### :bug: Bug Fixes
+- [`0c26ca5`](https://github.com/forumone/wp-cfm/commit/0c26ca566cc07e11f490f1bd7ee58c9ed714a1c3) - **ci**: Trigger New WordPress.org Release *(PR #164 by @timnolte)*
+
+### :wrench: Chores
+- [`b59eea4`](https://github.com/forumone/wp-cfm/commit/b59eea4b23bef692fa9bac88e010cfc98700543f) - **ci**: Updates Deployment Workflow for Manual & Automated Deployments to WP.org *(commit by @timnolte)*
+- [`e25a5ab`](https://github.com/forumone/wp-cfm/commit/e25a5abc6058a8fe4e8f839630596cc4e65f6e7d) - **release**: Updates and builds for release 1.7.7 *(commit by @f1builder)*
+
+## 1.7.6 - 2023-10-31
 ### :bug: Bug Fixes
 - [`de3cac5`](https://github.com/forumone/wp-cfm/commit/de3cac52607d7879b07e62a42bac62dc7925e98a) - **readwrite**: Add check to skip pulling a bundle if there was no matching bundle file *(PR [#132](https://github.com/forumone/wp-cfm/pull/132) by [@jessedyck](https://github.com/jessedyck))*
 - [`e6fd2c7`](https://github.com/forumone/wp-cfm/commit/e6fd2c7e14041a9c0d79d850f31d25d593cafae4) - **core**: Swap instances of filter_input for sanitize_text_field *(PR [#136](https://github.com/forumone/wp-cfm/pull/136) by [@gbeezus](https://github.com/gbeezus))*


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/forumone/wp-cfm/blob/develop/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

* Fixes the release GHA to use the 0.0.0 version tag format instead of v0.0.0.
* Fixes `CHANGELOG.md`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
* Fixes the release GHA to use the 0.0.0 version tag format instead of v0.0.0.

