### PR TITLE
chore(PHPStan): Fixes PHPStan linting errors in security patch

### DIFF
--- a/includes/class-ajax.php
+++ b/includes/class-ajax.php
@@ -28,7 +28,7 @@ class WPCFM_Ajax {
 			);
 		}
 
-		wp_send_json_error( array( 'message' => __( 'Unauthorized request!', 'wp-cfm' ) ), '403' );
+		wp_send_json_error( array( 'message' => __( 'Unauthorized request!', 'wp-cfm' ) ), 403 );
 	}
 
 
@@ -60,7 +60,7 @@ class WPCFM_Ajax {
 			);
 		}
 
-		wp_send_json_error( array( 'message' => __( 'Unauthorized request!', 'wp-cfm' ) ), '403' );
+		wp_send_json_error( array( 'message' => __( 'Unauthorized request!', 'wp-cfm' ) ), 403 );
 	}
 
 
@@ -85,7 +85,7 @@ class WPCFM_Ajax {
 			);
 		}
 
-		wp_send_json_error( array( 'message' => __( 'Unauthorized request!', 'wp-cfm' ) ), '403' );
+		wp_send_json_error( array( 'message' => __( 'Unauthorized request!', 'wp-cfm' ) ), 403 );
 	}
 
 
@@ -104,7 +104,7 @@ class WPCFM_Ajax {
 			);
 		}
 
-		wp_send_json_error( array( 'success' => false ), '403' );
+		wp_send_json_error( array( 'success' => false ), 403 );
 	}
 
 
@@ -123,6 +123,6 @@ class WPCFM_Ajax {
 			);
 		}
 
-		wp_send_json_error( array( 'message' => __( 'Unauthorized request!', 'wp-cfm' ) ), '403' );
+		wp_send_json_error( array( 'message' => __( 'Unauthorized request!', 'wp-cfm' ) ), 403 );
 	}
 }

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'forumone/wp-cfm',
         'pretty_version' => 'dev-develop',
         'version' => 'dev-develop',
-        'reference' => '648ae5abc2fdcbdbf5e5487979ae113c2c5c543d',
+        'reference' => 'b038166c5786e744a93c902066091c339647a647',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -22,7 +22,7 @@
         'forumone/wp-cfm' => array(
             'pretty_version' => 'dev-develop',
             'version' => 'dev-develop',
-            'reference' => '648ae5abc2fdcbdbf5e5487979ae113c2c5c543d',
+            'reference' => 'b038166c5786e744a93c902066091c339647a647',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/forumone/wp-cfm/blob/develop/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Updates the `wp_send_json_error` calls to pass the proper type based on the method signature.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

